### PR TITLE
新版本pyaml需要Loader参数。 | opencv相机初始化缓慢。

### DIFF
--- a/4/现实.py
+++ b/4/现实.py
@@ -63,8 +63,10 @@ def 捕捉循环():
     global 特征组
     原点特征组 = 提取图片特征(cv2.imread('../res/std_face.jpg'))
     特征组 = 原点特征组 - 原点特征组
-    cap = cv2.VideoCapture(0)
+    cap = cv2.VideoCapture(0, cv2.CAP_DSHOW)
+    end_time = time.time()
     logging.warning('开始捕捉了！')
+    logging.warning(f'捕捉线程启动耗时:{end_time - start_time:.2f}s')
     while True:
         ret, img = cap.read()
         新特征组 = 提取图片特征(img)
@@ -77,9 +79,11 @@ def 获取特征组():
     return 特征组
 
 
+
 t = threading.Thread(target=捕捉循环)
 t.setDaemon(True)
 t.start()
+start_time = time.time()
 logging.warning('捕捉线程启动中……')
 
 if __name__ == '__main__':

--- a/4/虚境.py
+++ b/4/虚境.py
@@ -32,7 +32,7 @@ def 提取图层(psd):
 
 def 添加深度信息(所有图层):
     with open('深度.yaml', encoding='utf8') as f:
-        深度信息 = yaml.load(f)
+        深度信息 = yaml.load(f,Loader=yaml.FullLoader)
     for 图层信息 in 所有图层:
         if 图层信息['名字'] in 深度信息:
             图层信息['深度'] = 深度信息[图层信息['名字']]


### PR DESCRIPTION
碰到的一些小坑。
issue1:
![Snipaste_2024-08-10_10-57-46](https://github.com/user-attachments/assets/32d25ee7-7c97-4103-9906-5f7e1baeec5c)
issue2:
![Snipaste_2024-08-10_10-56-27](https://github.com/user-attachments/assets/f0de45dc-7cf2-4446-9a6b-785157e1111e)

issue2参考:
[opencv的摄像机初始化耗时长的解决。](http://xnnehang.top/blog/86)  
DirectShow (cv2.CAP_DSHOW)：
  DirectShow 是 Windows 上较为直接和高效的视频捕获框架。指定 cv2.CAP_DSHOW 后，OpenCV 会直接调用 DirectShow 进行视频捕获。
  由于 DirectShow 更为轻量，且没有像其他后端那样加载那么多额外的组件，因此打开摄像头的速度更快。